### PR TITLE
sigma should be  1D sequence of same length as y

### DIFF
--- a/Raman Spectroscopy/PythonCode/raman_analysis_clean.py
+++ b/Raman Spectroscopy/PythonCode/raman_analysis_clean.py
@@ -52,7 +52,8 @@ def func(x, *params):
 
 def fit_lorentzians(guess, func, x, y):
     # Uses scipy curve_fit to optimise the lorentzian fitting
-    popt, pcov = curve_fit(func, x, y, p0=guess, maxfev=14000, sigma=2)
+    sigma = [2] * len(y)
+    popt, pcov = curve_fit(func, x, y, p0=guess, maxfev=14000, sigma=sigma)
     print('popt:', popt)
     fit = func(x, *popt)
     # pyplot.plot(x, y)


### PR DESCRIPTION
In this sigma is set to 2, which is a scalar. This is incorrect unless your y data (y) consists of exactly one point.

Instead, sigma should be a 1-D sequence of the same length as y, and it should contain positive numbers representing the standard deviations of the errors in y.

Change it to like this:

sigma = [2] * len(y)
popt, pcov = curve_fit(func, x, y, p0=guess, maxfev=14000, sigma=sigma)